### PR TITLE
Don't use numbered option in docs tutorial

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -6,7 +6,6 @@ This page summarizes the available tutorials.
 
 .. toctree::
    :maxdepth: 1
-   :numbered:
    :glob:
 
    *


### PR DESCRIPTION
This option causes wonky numbering in the tutorials in sphinx docs (e.g. #, ##, ### --> 1, 1.1, 1.1.1). Let's revert it and decide about the thumbnail images later