### PR TITLE
Always show type hints in docs

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -10,6 +10,7 @@
 .. autoclass:: {{ objname }}
    :no-members:
    :no-inherited-members:
+   :no-special-members:
    :show-inheritance:
 
 {% block attributes_summary %}

--- a/docs/_templates/autosummary/function.rst
+++ b/docs/_templates/autosummary/function.rst
@@ -1,5 +1,0 @@
-{{ objname | escape | underline}}
-
-.. currentmodule:: {{ module }}
-
-.. auto{{ objtype }}:: {{ objname }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,16 +74,16 @@ rst_prolog = f"""
 .. |version| replace:: {release}
 """
 
-# Options for autodoc. These reflect the values from Terra.
+# Options for autodoc. These reflect the values from Qiskit SDK and Runtime.
 autosummary_generate = True
 autosummary_generate_overwrite = False
 autoclass_content = "both"
 autodoc_typehints = "description"
-autodoc_typehints_description_target = "documented_params"
-autodoc_member_order = "bysource"
 autodoc_default_options = {
     "inherited-members": None,
 }
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
 
 
 # This adds numbers to the captions for figures, tables,


### PR DESCRIPTION
Before, we would only show type hints for parameters that had dedicated docstring. There are a lot of parameters that don't have docstring—and sometimes don't need it because it's obvious—so it's best to no matter what show the docstring.

This PR aligns the autodoc templates and config with the other addons like cutting.