### PR TITLE
Add Lindblad Noise Support

### DIFF
--- a/qiskit_addon_obp/backpropagation.py
+++ b/qiskit_addon_obp/backpropagation.py
@@ -34,6 +34,7 @@ from .utils.operations import (
 from .utils.simplify import OperatorBudget
 from .utils.simplify import simplify as simplify_sparse_pauli_op
 from .utils.truncating import TruncationErrorBudget, truncate_binary_search
+from .utils.lindblad_noise import evolve_ple_spo
 
 LOGGER = logging.getLogger(__name__)
 
@@ -147,10 +148,18 @@ def backpropagate(
             slice_metadata = SliceMetadata(
                 slice_errors=[0.0] * num_observables,
                 raw_num_paulis=[0] * num_observables,
-                num_unique_paulis=[0] * num_observables if operator_budget.simplify else None,
-                num_duplicate_paulis=[0] * num_observables if operator_budget.simplify else None,
-                num_trimmed_paulis=[0] * num_observables if operator_budget.simplify else None,
-                sum_trimmed_coeffs=[0] * num_observables if operator_budget.simplify else None,
+                num_unique_paulis=[0] * num_observables
+                if operator_budget.simplify
+                else None,
+                num_duplicate_paulis=[0] * num_observables
+                if operator_budget.simplify
+                else None,
+                num_trimmed_paulis=[0] * num_observables
+                if operator_budget.simplify
+                else None,
+                sum_trimmed_coeffs=[0] * num_observables
+                if operator_budget.simplify
+                else None,
                 num_truncated_paulis=[0] * num_observables,
                 num_paulis=[0] * num_observables,
                 sum_paulis=None,
@@ -164,7 +173,9 @@ def backpropagate(
             # PERF: we will likely need to parallelize this loop
             for i in range(num_observables):
                 non_trivial_slice = False
-                for op_idx, op_node in enumerate(circuit_to_dag(slice_).topological_op_nodes()):
+                for op_idx, op_node in enumerate(
+                    circuit_to_dag(slice_).topological_op_nodes()
+                ):
                     # Ignore barriers within slices
                     if op_node.name == "barrier":
                         continue
@@ -183,7 +194,13 @@ def backpropagate(
                     non_trivial_slice = True
 
                     if op_node.name == "reset":
-                        observables_tmp[i] = apply_reset_to(observables_tmp[i], qargs_tmp[i][0])
+                        observables_tmp[i] = apply_reset_to(
+                            observables_tmp[i], qargs_tmp[i][0]
+                        )
+                    elif op_node.name == "LayerError":
+                        observables_tmp[i] = evolve_ple_spo(
+                            spo=observables_tmp[i], ple_instr=op_node.op
+                        )
                     else:
                         # Absorb gate into observable and update qubits on which the observable acts
                         observables_tmp[i], qargs_tmp[i] = apply_op_to(
@@ -197,8 +214,8 @@ def backpropagate(
                     slice_metadata.raw_num_paulis[i] = len(observables_tmp[i])
 
                     if operator_budget.simplify:
-                        observables_tmp[i], simplify_metadata = simplify_sparse_pauli_op(
-                            observables_tmp[i]
+                        observables_tmp[i], simplify_metadata = (
+                            simplify_sparse_pauli_op(observables_tmp[i])
                         )
                         slice_metadata.num_unique_paulis[i] = (  # type: ignore[index]
                             simplify_metadata.num_unique_paulis
@@ -225,7 +242,9 @@ def backpropagate(
                         metadata,
                         i,
                     )
-                    slice_metadata.num_truncated_paulis[i] = previous_size - len(observables_tmp[i])
+                    slice_metadata.num_truncated_paulis[i] = previous_size - len(
+                        observables_tmp[i]
+                    )
 
                 slice_metadata.num_paulis[i] = len(observables_tmp[i])
 
@@ -271,14 +290,17 @@ def backpropagate(
         if max_seconds is not None:
             signal.alarm(0)
 
-    LOGGER.info(f"Backpropagated {metadata.num_backpropagated_slices} DAG multi-graph slices")
+    LOGGER.info(
+        f"Backpropagated {metadata.num_backpropagated_slices} DAG multi-graph slices"
+    )
 
     # Return the slices which were not backpropagated
     slices_out = slices[: -metadata.num_backpropagated_slices]
 
     # Specify the output observables on all qubits in the circuit
     obs_out = [
-        to_global_op(obs, qargs, num_qubits) for obs, qargs in zip(observables_out, qargs_out)
+        to_global_op(obs, qargs, num_qubits)
+        for obs, qargs in zip(observables_out, qargs_out)
     ]
     # If the input was a single observable, return a single observable
     if isinstance(observables, SparsePauliOp):
@@ -320,7 +342,9 @@ def _validate_input_options(
     max_paulis = operator_budget.max_paulis
     max_qwc_groups = operator_budget.max_qwc_groups
     if max_paulis is not None and max_paulis < 1:
-        raise ValueError("Limiting the number of Pauli terms to less than 1 does not make sense.")
+        raise ValueError(
+            "Limiting the number of Pauli terms to less than 1 does not make sense."
+        )
     if max_qwc_groups is not None and max_qwc_groups < 1:
         raise ValueError(
             "Limiting the number of qubit-wise commmuting Pauli groups to less than 1 does not "
@@ -330,7 +354,9 @@ def _validate_input_options(
         # combine all observables as global ones into one large one
         all_paulis = SparsePauliOp.from_list([], num_qubits=num_qubits)
         for obs in global_observables:
-            all_paulis += SparsePauliOp.from_list([(pauli, 1) for pauli, _ in obs.label_iter()])
+            all_paulis += SparsePauliOp.from_list(
+                [(pauli, 1) for pauli, _ in obs.label_iter()]
+            )
         all_paulis = all_paulis.simplify()
 
         if max_paulis is not None:
@@ -377,7 +403,9 @@ def _truncate_terms(
         f"{accumulated_error:.10f}"
     )
 
-    metadata.backpropagation_history[slice_idx].slice_errors[observable_idx] = slice_error
+    metadata.backpropagation_history[slice_idx].slice_errors[observable_idx] = (
+        slice_error
+    )
 
     return observable_out
 
@@ -397,13 +425,17 @@ def _observable_oversized(
     max_qwc_groups = operator_budget.max_qwc_groups
     for obs, qargs_ in zip(observables, qargs):
         global_obs = to_global_op(obs, qargs_, num_qubits)
-        all_paulis += SparsePauliOp.from_list([(pauli, 1) for pauli, _ in global_obs.label_iter()])
+        all_paulis += SparsePauliOp.from_list(
+            [(pauli, 1) for pauli, _ in global_obs.label_iter()]
+        )
     all_paulis = all_paulis.simplify()
 
     if max_paulis is not None:
         slice_metadata.sum_paulis = len(all_paulis)
         if slice_metadata.sum_paulis > max_paulis:
-            LOGGER.info(f"[{slice_id:3}] Too many Pauli terms: {slice_metadata.sum_paulis}")
+            LOGGER.info(
+                f"[{slice_id:3}] Too many Pauli terms: {slice_metadata.sum_paulis}"
+            )
             return True
 
     if max_qwc_groups is not None:
@@ -422,7 +454,9 @@ def _get_observable_and_qargs_lists(
     observables: SparsePauliOp | Sequence[SparsePauliOp],
 ) -> tuple[list[SparsePauliOp], list[list[int]]]:
     """Ensure observables and qargs are lists."""
-    observable_list = [observables] if isinstance(observables, SparsePauliOp) else list(observables)
+    observable_list = (
+        [observables] if isinstance(observables, SparsePauliOp) else list(observables)
+    )
 
     # Get lean representations of the observables (reduced obs + qargs)
     obs_out = []

--- a/qiskit_addon_obp/utils/lindblad_noise.py
+++ b/qiskit_addon_obp/utils/lindblad_noise.py
@@ -1,0 +1,146 @@
+from typing import Optional, Sequence
+
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.circuit import Instruction, QuantumRegister, Qubit
+from qiskit.quantum_info import Pauli, PauliList, SparsePauliOp
+from qiskit_aer.noise import pauli_error
+from qiskit_ibm_runtime.utils.noise_learner_result import PauliLindbladError
+
+
+class PauliLindbladErrorInstruction(Instruction):
+    def __init__(self, ple: PauliLindbladError, index: Optional[int] = None):
+        self._ple = ple
+        self._index = index
+        label = "LayerError"
+        if index is not None:
+            label = f"{label} {index}"
+        super().__init__(
+            name="LayerError",
+            num_qubits=self._ple.num_qubits,
+            num_clbits=0,
+            params=[],
+            label=label,
+        )
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, PauliLindbladErrorInstruction):
+            if self._index != other._index:
+                return False
+            if (self._ple.rates != other._ple.rates).any():
+                return False
+            if self._ple.generators != other._ple.generators:
+                return False
+            return True
+        return False
+
+    @property
+    def index(self):
+        if self._index is None:
+            raise ValueError(
+                "Index not defined, you probably didn't mean to call this."
+            )
+        return self._index
+
+    def _define(self):
+        self._definition = pauli_lindblad_error_to_qc(self._ple, instr=False)
+
+    def map_to_inds(
+        self, qargs: Sequence[Qubit], target_qreg: QuantumRegister
+    ) -> "PauliLindbladErrorInstruction":
+        qarg_map = {v: k for k, v in enumerate(list(target_qreg))}
+        qarg_inds = [qarg_map[qubit] for qubit in qargs]
+
+        x_ = np.zeros((len(self._ple.generators), len(target_qreg)))
+        z_ = np.zeros((len(self._ple.generators), len(target_qreg)))
+
+        x_[:, qarg_inds] = self._ple.generators.x
+        z_[:, qarg_inds] = self._ple.generators.z
+
+        return PauliLindbladErrorInstruction(
+            ple=PauliLindbladError(
+                generators=PauliList.from_symplectic(z_, x_, 0),
+                rates=self._ple.rates,
+            ),
+            index=self.index,
+        )
+
+
+class _PauliEvolutionData:
+    def __init__(
+        self,
+        gen: Pauli,
+        prop_pauli: Pauli,
+        prob: Optional[float] = None,
+        rate: Optional[float] = None,
+    ):
+        if prob is None and rate is None:
+            raise ValueError("must have either prob or rate defined")
+        if (prob is not None) and (rate is not None):
+            raise ValueError("cannot provide both rate and prob")
+
+        if prob is None:
+            prob_no_err = (1 + np.exp(-2 * rate)) / 2
+            prob = 1 - prob_no_err
+        if rate is None:
+            prob_no_err = 1 - prob
+            rate = -1 / 2 * np.log(2 * prob_no_err - 1)
+
+        self.rate = rate
+        self.prob = prob
+
+        self.gen = gen
+        self.prop_pauli = prop_pauli
+
+        self._ac = self.prop_pauli.anticommutes(self.gen)
+
+    @property
+    def fid(self):
+        if not self.anti_comm:
+            return 1.0
+        return 1 - 2.0 * self.prob
+
+    @property
+    def anti_comm(self):
+        return self._ac
+
+    @property
+    def comm(self):
+        return not self.anti_comm
+
+
+def evolve_pauli_lindblad_error_instruction(
+    pauli: Pauli,
+    ple_instr: PauliLindbladErrorInstruction,
+) -> tuple[float, np.ndarray]:
+    fid = 1.0
+    for gen, rate in zip(ple_instr._ple.generators, ple_instr._ple.rates):
+        _ped = _PauliEvolutionData(rate=rate, gen=gen, prop_pauli=pauli)
+        fid *= _ped.fid
+    return fid
+
+
+def pauli_lindblad_error_to_qc(ple: PauliLindbladError, instr: bool = True):
+    qc_res = QuantumCircuit(ple.num_qubits)
+    p_id = Pauli("I" * ple.num_qubits)
+    for pauli, rate in zip(ple.generators, ple.rates):
+        if pauli == p_id:
+            continue
+        prob_no_err = (1 + np.exp(-2 * rate)) / 2
+        err = pauli_error([(pauli, 1 - prob_no_err), (p_id, prob_no_err)])
+        qc_res.append(err, qargs=range(qc_res.num_qubits))
+    if instr:
+        return qc_res.to_instruction(label=ple.label)
+    return qc_res
+
+
+def evolve_ple_spo(
+    spo: SparsePauliOp,
+    ple_instr: PauliLindbladErrorInstruction,
+):
+    coeffs_new = []
+    for pauli, coeff in zip(spo.paulis, spo.coeffs):
+        _coeff = coeff
+        _coeff *= evolve_pauli_lindblad_error_instruction(pauli, ple_instr)
+        coeffs_new.append(_coeff)
+    return SparsePauliOp(spo.paulis, coeffs_new)

--- a/test/scratch.ipynb
+++ b/test/scratch.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit_addon_obp import backpropagate\n",
+    "from qiskit_addon_obp.utils.lindblad_noise import PauliLindbladError, PauliLindbladErrorInstruction\n",
+    "\n",
+    "from qiskit.quantum_info import SparsePauliOp, PauliList\n",
+    "from qiskit import QuantumCircuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"word-wrap: normal;white-space: pre;background: #fff0;line-height: 1.1;font-family: &quot;Courier New&quot;,Courier,monospace\">     ┌───┐ ░      ┌─────────────┐ ░ \n",
+       "q_0: ┤ H ├─░───■──┤0            ├─░─\n",
+       "     └───┘ ░ ┌─┴─┐│  Layererror │ ░ \n",
+       "q_1: ──────░─┤ X ├┤1            ├─░─\n",
+       "           ░ └───┘└─────────────┘ ░ </pre>"
+      ],
+      "text/plain": [
+       "     ┌───┐ ░      ┌─────────────┐ ░ \n",
+       "q_0: ┤ H ├─░───■──┤0            ├─░─\n",
+       "     └───┘ ░ ┌─┴─┐│  Layererror │ ░ \n",
+       "q_1: ──────░─┤ X ├┤1            ├─░─\n",
+       "           ░ └───┘└─────────────┘ ░ "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lerr = PauliLindbladError(PauliList([\"IX\"]), [1e-3])\n",
+    "lerr_instr = PauliLindbladErrorInstruction(lerr)\n",
+    "\n",
+    "op = SparsePauliOp([\"XY\", \"ZI\", \"II\"], [3, 2, 1])\n",
+    "\n",
+    "slices = []\n",
+    "\n",
+    "qc_base = QuantumCircuit(2)\n",
+    "\n",
+    "qc = qc_base.copy_empty_like()\n",
+    "qc.h(0)\n",
+    "slices.append(qc)\n",
+    "\n",
+    "qc = qc_base.copy_empty_like()\n",
+    "qc.cx(0, 1)\n",
+    "qc.append(lerr_instr, [0, 1])\n",
+    "slices.append(qc)\n",
+    "\n",
+    "qc_full = qc_base.copy_empty_like()\n",
+    "for sl in slices:\n",
+    "    qc_full.compose(sl, inplace=True)\n",
+    "    qc_full.barrier()\n",
+    "qc_full.draw(fold=-1,)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "op_prop, remaining_slices, metadata = backpropagate(\n",
+    "    observables=[op],\n",
+    "    slices=slices,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[SparsePauliOp(['IY', 'II', 'ZX'],\n",
+       "               coeffs=[-2.994006+0.j,  1.      +0.j,  1.996004+0.j])]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "op_prop"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This is a preliminary/WIP/draft PR that adds some relevant classes to enable using Lindblad errors as instructions in a circuit when using OBP.

Some of the classes in this PR have significant overlap with those in [`qiskit-ibm-runtime`](https://github.com/Qiskit/qiskit-ibm-runtime/) and therefore may belong better there (or just have the functionality added there instead or something).

Something that we would also want would be a way of placing the Pauli Lindblad channels into the circuits and slices in the appropriate places, etc.