### PR TITLE
Add ability to set truncation threshold for `SparsePauliOp`'s simplify method

### DIFF
--- a/qiskit_addon_obp/backpropagation.py
+++ b/qiskit_addon_obp/backpropagation.py
@@ -198,7 +198,9 @@ def backpropagate(
 
                     if operator_budget.simplify:
                         observables_tmp[i], simplify_metadata = simplify_sparse_pauli_op(
-                            observables_tmp[i]
+                            observables_tmp[i],
+                            operator_budget.atol,
+                            operator_budget.rtol
                         )
                         slice_metadata.num_unique_paulis[i] = (  # type: ignore[index]
                             simplify_metadata.num_unique_paulis

--- a/qiskit_addon_obp/backpropagation.py
+++ b/qiskit_addon_obp/backpropagation.py
@@ -199,8 +199,8 @@ def backpropagate(
                     if operator_budget.simplify:
                         observables_tmp[i], simplify_metadata = simplify_sparse_pauli_op(
                             observables_tmp[i],
-                            operator_budget.atol,
-                            operator_budget.rtol
+                            atol = operator_budget.atol,
+                            rtol = operator_budget.rtol
                         )
                         slice_metadata.num_unique_paulis[i] = (  # type: ignore[index]
                             simplify_metadata.num_unique_paulis

--- a/qiskit_addon_obp/utils/simplify.py
+++ b/qiskit_addon_obp/utils/simplify.py
@@ -75,6 +75,10 @@ class OperatorBudget:
     simplify: bool = True
     """A flag denoting whether to call :func:`simplify` at every iteration."""
 
+    atol: float = 1e-8
+
+    rtol: float = 1e-5
+
     def is_active(self) -> bool:
         """Return whether ``self`` places any bounds on operator size."""
         return self.max_paulis is not None or self.max_qwc_groups is not None


### PR DESCRIPTION
`SparsePauliOp.simplify()` has an implicit threshold for truncating small coefficients, the truncation of these coefficients is not tracked by OBP's error budgeting, so these parameters need to be exposed to users as they introduce un-accounted for sources of error. 

The solution implemented here is to add the absolute and relative tolerance values `atol`, `rtol`, to the `OperatorBudget` data structure. These values are then passed along to `SparsePauliOp.simplify` when it gets called. 