### PR TITLE
Allow users to specify tolerance for finding optimal truncation thresholds

### DIFF
--- a/docs/_static/dummy_visualization_metadata.json
+++ b/docs/_static/dummy_visualization_metadata.json
@@ -4,7 +4,8 @@
       0.001
     ],
     "max_error_total": 0.01,
-    "p_norm": 1
+    "p_norm": 1,
+    "tol": 1e-06
   },
   "num_slices": null,
   "operator_budget": {

--- a/qiskit_addon_obp/backpropagation.py
+++ b/qiskit_addon_obp/backpropagation.py
@@ -369,6 +369,7 @@ def _truncate_terms(
         observable,
         left_over_error_budget,
         p_norm=p_norm,
+        tol=metadata.truncation_error_budget.atol,
     )
 
     accumulated_error = metadata.accumulated_error(observable_idx, slice_idx + 1)

--- a/qiskit_addon_obp/backpropagation.py
+++ b/qiskit_addon_obp/backpropagation.py
@@ -369,7 +369,7 @@ def _truncate_terms(
         observable,
         left_over_error_budget,
         p_norm=p_norm,
-        tol=metadata.truncation_error_budget.atol,
+        tol=metadata.truncation_error_budget.tol,
     )
 
     accumulated_error = metadata.accumulated_error(observable_idx, slice_idx + 1)

--- a/qiskit_addon_obp/utils/truncating.py
+++ b/qiskit_addon_obp/utils/truncating.py
@@ -168,7 +168,9 @@ def truncate_binary_search(
     lower_error = 0.0
 
     # binary search for a cutoff threshold
-    while ((upper_threshold - lower_threshold) > 1e-10) and not (np.isclose(upper_error, lower_error)):
+    while ((upper_threshold - lower_threshold) > 1e-10) and not (
+        np.isclose(upper_error, lower_error)
+    ):
         mid_threshold = (upper_threshold + lower_threshold) / 2
         # PERF: the boolean indexing here will need to check every element in the array at every
         # iteration of this loop. We can improve the performance by performing successive

--- a/qiskit_addon_obp/utils/truncating.py
+++ b/qiskit_addon_obp/utils/truncating.py
@@ -49,8 +49,8 @@ class TruncationErrorBudget:
     """
 
     tol: float = 1e-8
-    """Tolerance used during truncation. Once an optimal threshold, up to this tolerance,
-    has been found, the search for an optimal truncation threshold will stop.
+    """Absolute tolerance used during truncation. Once an optimal truncation threshold, up
+    to this tolerance, has been found, the search for an optimal threshold will stop.
     """
 
     def is_active(self) -> bool:

--- a/qiskit_addon_obp/utils/truncating.py
+++ b/qiskit_addon_obp/utils/truncating.py
@@ -174,7 +174,7 @@ def truncate_binary_search(
     lower_threshold = 0.0
     upper_error = budget
     lower_error = 0.0
-    
+
     # binary search for a cutoff threshold
     while ((upper_threshold - lower_threshold) > tol) and not (
         np.isclose(upper_error, lower_error, atol=tol)

--- a/qiskit_addon_obp/utils/truncating.py
+++ b/qiskit_addon_obp/utils/truncating.py
@@ -177,8 +177,8 @@ def truncate_binary_search(
     upper_error = budget
     lower_error = 0.0
     # binary search for a cutoff threshold
-    while ((upper_threshold - lower_threshold) > 1e-10) and not (
-        np.isclose(upper_error, lower_error)
+    while ((upper_threshold - lower_threshold) > tol) and not (
+        np.isclose(upper_error, lower_error, atol=tol)
     ):
         mid_threshold = (upper_threshold + lower_threshold) / 2
         # PERF: the boolean indexing here will need to check every element in the array at every

--- a/qiskit_addon_obp/utils/truncating.py
+++ b/qiskit_addon_obp/utils/truncating.py
@@ -146,7 +146,7 @@ def truncate_binary_search(
     budget: float,
     *,
     p_norm: int = 1,
-    tol: float | None = None,
+    tol: float = 1e-8,
 ) -> tuple[SparsePauliOp, float]:
     r"""Perform binary search to find an optimal observable truncation threshold.
 
@@ -168,9 +168,6 @@ def truncate_binary_search(
            truncated terms' coefficient magnitudes, :math:`c`, such that :math:`E = \|c\|_p`.
 
     """
-    # Use Qiskit default tolerance of 1e-8
-    tol = tol or 1e-8
-
     abscs = np.abs(observable.coeffs) ** p_norm
     upper_threshold = max(abscs)
     lower_threshold = 0.0

--- a/qiskit_addon_obp/utils/truncating.py
+++ b/qiskit_addon_obp/utils/truncating.py
@@ -168,7 +168,7 @@ def truncate_binary_search(
     lower_error = 0.0
 
     # binary search for a cutoff threshold
-    while ((upper_threshold - lower_threshold) > 1e-10) and (upper_error != lower_error):
+    while ((upper_threshold - lower_threshold) > 1e-10) and not (np.isclose(upper_error, lower_error)):
         mid_threshold = (upper_threshold + lower_threshold) / 2
         # PERF: the boolean indexing here will need to check every element in the array at every
         # iteration of this loop. We can improve the performance by performing successive
@@ -186,7 +186,7 @@ def truncate_binary_search(
             upper_error = mid_error
 
     # delete according to lower_threshold
-    to_keep = abscs > lower_threshold
+    to_keep = abscs >= lower_threshold
 
     return (
         SparsePauliOp(observable.paulis[to_keep], observable.coeffs[to_keep]),

--- a/qiskit_addon_obp/utils/truncating.py
+++ b/qiskit_addon_obp/utils/truncating.py
@@ -169,10 +169,12 @@ def truncate_binary_search(
 
     """
     abscs = np.abs(observable.coeffs) ** p_norm
+
     upper_threshold = max(abscs)
     lower_threshold = 0.0
     upper_error = budget
     lower_error = 0.0
+    
     # binary search for a cutoff threshold
     while ((upper_threshold - lower_threshold) > tol) and not (
         np.isclose(upper_error, lower_error, atol=tol)

--- a/qiskit_addon_obp/utils/truncating.py
+++ b/qiskit_addon_obp/utils/truncating.py
@@ -194,7 +194,7 @@ def truncate_binary_search(
             upper_error = mid_error
 
     # delete according to lower_threshold
-    to_keep = abscs >= lower_threshold
+    to_keep = abscs > lower_threshold
 
     return (
         SparsePauliOp(observable.paulis[to_keep], observable.coeffs[to_keep]),

--- a/releasenotes/notes/trunc-tol-a1c03cf32154e58f.yaml
+++ b/releasenotes/notes/trunc-tol-a1c03cf32154e58f.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    :func:`~.truncate_binary_search` now accepts a ``tol`` kwarg. Once an optimal truncation threshold, up to this value, has been found, the search for an optimal threshold will stop.
+    :func:`~.truncate_binary_search` now accepts a ``tol`` kwarg. Once an optimal truncation threshold, up to this value, has been found, the search for an optimal threshold will stop. The default tolerance is ``1e-8``; whereas, the tolerance used prior to this release was ``1e-10``.
 
     :class:`~.TruncationErrorBudget` now holds a ``tol`` field. This field is used by :func:`~.backpropagate` as the ``tol`` argument to :func:`~.truncate_binary_search`.

--- a/releasenotes/notes/trunc-tol-a1c03cf32154e58f.yaml
+++ b/releasenotes/notes/trunc-tol-a1c03cf32154e58f.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    :func:`qiskit_addon_obp.utils.truncating.truncate_binary_search` now accepts a ``tol`` kwarg. Once an optimal truncation threshold, up to this value, has been found, the search for an optimal threshold will stop.
+    :func:`~.truncate_binary_search` now accepts a ``tol`` kwarg. Once an optimal truncation threshold, up to this value, has been found, the search for an optimal threshold will stop.
 
-    :class:`qiskit_addon_obp.utils.truncating.TruncationErrorBudget` now holds a ``tol`` field. This field is used by :func:`qiskit_addon_obp.backpropagate` as the ``tol`` argument to :func:`qiskit_addon_obp.utils.truncating.truncate_binary_search`.
+    :class:`~.TruncationErrorBudget` now holds a ``tol`` field. This field is used by :func:`~.backpropagate` as the ``tol`` argument to :func:`~.truncate_binary_search`.

--- a/releasenotes/notes/trunc-tol-a1c03cf32154e58f.yaml
+++ b/releasenotes/notes/trunc-tol-a1c03cf32154e58f.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    :func:`qiskit_addon_obp.utils.truncating.truncate_binary_search` now accepts a ``tol`` kwarg. Once an optimal truncation threshold, up to this value, has been found, the search for an optimal threshold will stop.
+
+    :class:`qiskit_addon_obp.utils.truncating.TruncationErrorBudget` now holds a ``tol`` field. This field is used by :func:`qiskit_addon_obp.backpropagate` as the ``tol`` argument to :func:`qiskit_addon_obp.utils.truncating.truncate_binary_search`.

--- a/test/utils/test_metadata.py
+++ b/test/utils/test_metadata.py
@@ -26,7 +26,7 @@ from qiskit_addon_obp.utils.truncating import TruncationErrorBudget
 class TestOBPMetadata(unittest.TestCase):
     def setUp(self) -> None:
         self.expected = OBPMetadata(
-            truncation_error_budget=TruncationErrorBudget([0.001], 0.01, 1),
+            truncation_error_budget=TruncationErrorBudget([0.001], 0.01, 1, 1e-6),
             num_slices=None,
             operator_budget=OperatorBudget(50, 12, True),
             backpropagation_history=[


### PR DESCRIPTION
This PR addresses the arbitrary `1e-10` tolerance being used in the binary search for an optimal truncation threshold.

Instead of having this arbitrary, hard-coded value, let's allow the user to specify a tolerance in the truncation budget class. For consistency, we can set the default to Qiskit's typical default of `1e-8`, although we don't actually call any Qiskit function directly