### PR TITLE
Allow users to specify tolerances for operator simplify.

### DIFF
--- a/docs/_static/dummy_visualization_metadata.json
+++ b/docs/_static/dummy_visualization_metadata.json
@@ -10,7 +10,9 @@
   "operator_budget": {
     "max_paulis": 50,
     "max_qwc_groups": 12,
-    "simplify": true
+    "simplify": true,
+    "atol": 1e-08,
+    "rtol": 1e-08
   },
   "backpropagation_history": [
     {

--- a/docs/_static/dummy_visualization_metadata.json
+++ b/docs/_static/dummy_visualization_metadata.json
@@ -11,8 +11,8 @@
     "max_paulis": 50,
     "max_qwc_groups": 12,
     "simplify": true,
-    "atol": 1e-08,
-    "rtol": 1e-08
+    "atol": null,
+    "rtol": null
   },
   "backpropagation_history": [
     {

--- a/docs/_static/dummy_visualization_metadata.json
+++ b/docs/_static/dummy_visualization_metadata.json
@@ -11,8 +11,8 @@
     "max_paulis": 50,
     "max_qwc_groups": 12,
     "simplify": true,
-    "atol": null,
-    "rtol": null
+    "atol": 1e-10,
+    "rtol": 1e-10
   },
   "backpropagation_history": [
     {

--- a/qiskit_addon_obp/backpropagation.py
+++ b/qiskit_addon_obp/backpropagation.py
@@ -199,7 +199,9 @@ def backpropagate(
 
                     if operator_budget.simplify:
                         observables_tmp[i], simplify_metadata = simplify_sparse_pauli_op(
-                            observables_tmp[i]
+                            observables_tmp[i],
+                            atol=operator_budget.atol,
+                            rtol=operator_budget.rtol,
                         )
                         slice_metadata.num_unique_paulis[i] = (  # type: ignore[index]
                             simplify_metadata.num_unique_paulis

--- a/qiskit_addon_obp/utils/simplify.py
+++ b/qiskit_addon_obp/utils/simplify.py
@@ -64,6 +64,12 @@ class OperatorBudget:
     simplify: bool = True
     """A flag denoting whether to call :func:`simplify` at every iteration."""
 
+    atol: float = 1e-8
+    """Absolute tolerance for checking if coefficients are zero."""
+
+    atol: float = 1e-8
+    """Relative tolerance for checking if coefficients are zero."""
+
     def is_active(self) -> bool:
         """Return whether ``self`` places any bounds on operator size."""
         return self.max_paulis is not None or self.max_qwc_groups is not None

--- a/qiskit_addon_obp/utils/simplify.py
+++ b/qiskit_addon_obp/utils/simplify.py
@@ -64,11 +64,11 @@ class OperatorBudget:
     simplify: bool = True
     """A flag denoting whether to call :func:`simplify` at every iteration."""
 
-    atol: float = 1e-8
-    """Absolute tolerance for checking if coefficients are zero."""
+    atol: float | None = None
+    """Absolute tolerance for checking if coefficients are zero. Defaults to :meth:`qiskit.quantum_info.SparsePauliOp.simplify` value."""
 
-    rtol: float = 1e-8
-    """Relative tolerance for checking if coefficients are zero."""
+    rtol: float | None = None
+    """Relative tolerance for checking if coefficients are zero. Defaults to :meth:`qiskit.quantum_info.SparsePauliOp.simplify` value."""
 
     def is_active(self) -> bool:
         """Return whether ``self`` places any bounds on operator size."""

--- a/qiskit_addon_obp/utils/simplify.py
+++ b/qiskit_addon_obp/utils/simplify.py
@@ -65,10 +65,12 @@ class OperatorBudget:
     """A flag denoting whether to call :func:`simplify` at every iteration."""
 
     atol: float | None = None
-    """Absolute tolerance for checking if coefficients are zero. Defaults to :meth:`qiskit.quantum_info.SparsePauliOp.simplify` value."""
+    """Absolute tolerance for checking if coefficients are zero. Defaults to the
+    :attr:`~qiskit.quantum_info.SparsePauliOp.atol` value of ``SparsePauliOp``."""
 
     rtol: float | None = None
-    """Relative tolerance for checking if coefficients are zero. Defaults to :meth:`qiskit.quantum_info.SparsePauliOp.simplify` value."""
+    """Relative tolerance for checking if coefficients are zero. Defaults to the
+    :attr:`~qiskit.quantum_info.SparsePauliOp.rtol` value of ``Sparse``."""
 
     def is_active(self) -> bool:
         """Return whether ``self`` places any bounds on operator size."""

--- a/qiskit_addon_obp/utils/simplify.py
+++ b/qiskit_addon_obp/utils/simplify.py
@@ -67,7 +67,7 @@ class OperatorBudget:
     atol: float = 1e-8
     """Absolute tolerance for checking if coefficients are zero."""
 
-    atol: float = 1e-8
+    rtol: float = 1e-8
     """Relative tolerance for checking if coefficients are zero."""
 
     def is_active(self) -> bool:

--- a/releasenotes/notes/tol-077b4d12aa30bc39.yaml
+++ b/releasenotes/notes/tol-077b4d12aa30bc39.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    :class:`qiskit_addon_obp.utils.simplify.OperatorBudget` now holds ``atol`` and ``rtol`` fields which are absolute and relative tolerances used to determine whether coefficients are zero while simplifying an operator.
+    

--- a/test/utils/test_metadata.py
+++ b/test/utils/test_metadata.py
@@ -28,7 +28,7 @@ class TestOBPMetadata(unittest.TestCase):
         self.expected = OBPMetadata(
             truncation_error_budget=TruncationErrorBudget([0.001], 0.01, 1),
             num_slices=None,
-            operator_budget=OperatorBudget(50, 12, True),
+            operator_budget=OperatorBudget(50, 12, True, 1e-10, 1e-10),
             backpropagation_history=[
                 SliceMetadata(
                     slice_errors=[0.0, 0.0],


### PR DESCRIPTION
Original PR : #59 

`SparsePauliOp.simplify()` has an implicit threshold for truncating small coefficients, the truncation of these coefficients is not tracked by OBP's error budgeting, so these parameters need to be exposed to users as they introduce un-accounted for sources of error. 

The solution implemented here is to add the absolute and relative tolerance values `atol`, `rtol`, to the `OperatorBudget` data structure. These values are then passed along to `SparsePauliOp.simplify` when it gets called. 