### PR TITLE
test: improve timeout testing by monkeypatching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
 basetest = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pytest-subtests>=0.13",
     "qiskit-addon-utils",
 ]
 test = [

--- a/test/test_backpropagation.py
+++ b/test/test_backpropagation.py
@@ -13,7 +13,6 @@
 """Tests for operator backpropagation utility functions."""
 
 import sys
-import time
 import unittest
 from math import e
 from time import sleep
@@ -870,7 +869,9 @@ class TestBackpropagation(unittest.TestCase):
             with self.assertRaises(ValueError):
                 backpropagate(obs, slices, operator_budget=op_budget)
 
-    def test_backpropagate_timeout(self):
+
+class TestBackpropagationTimeout:
+    def test_backpropagate_timeout(self, subtests, monkeypatch):
         qc = QuantumCircuit(2)
         qc.rx(0.1, 0)
         qc.ry(0.1, 0)
@@ -879,34 +880,46 @@ class TestBackpropagation(unittest.TestCase):
         slices = slice_by_depth(qc, 1)
         obs = SparsePauliOp("IX")
 
+        timeout_triggered = False
+
+        class MyTimeout(Exception):
+            def __init__(self):
+                nonlocal timeout_triggered
+                timeout_triggered = True
+
+        monkeypatch.setattr("qiskit_addon_obp.backpropagation.TimeoutException", MyTimeout)
+
         on_win = sys.platform == "win32"
-        with self.subTest("Actual timeout"):
+        with subtests.test(msg="Actual timeout"):
             if on_win:
                 pytest.skip("Does not run on Windows")
             many_slices = 100_000 * slices
-            t1 = time.time()
+
             _, new_qc, _ = backpropagate(obs, many_slices, max_seconds=1)
-            t2 = time.time()
 
-            with self.subTest("Time should be less than 2 seconds"):
-                assert (t2 - t1) < 2
+            with subtests.test(msg="Time should be less than 2 seconds"):
+                assert timeout_triggered
 
-            with self.subTest("The resulting circuit should not be empty"):
+            with subtests.test(msg="The resulting circuit should not be empty"):
                 assert len(new_qc) > 0
 
-        with self.subTest("Reset timeout"):
+        timeout_triggered = False
+
+        with subtests.test(msg="Reset timeout"):
             if on_win:
                 pytest.skip("Does not run on Windows")
-            t1 = time.time()
-            _, new_qc, _ = backpropagate(obs, slices, max_seconds=1)
-            t2 = time.time()
 
-            with self.subTest("The resulting circuit should be empty"):
+            _, new_qc, _ = backpropagate(obs, slices, max_seconds=1)
+
+            with subtests.test(msg="No timeout should have occurred"):
+                assert not timeout_triggered
+
+            with subtests.test(msg="The resulting circuit should be empty"):
                 assert len(new_qc) == 0
 
             sleep(1)
 
-        with self.subTest("Handle windows"):
+        with subtests.test(msg="Handle windows"):
             if not on_win:
                 pytest.skip("Only on Windows")
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Closes #39 

This fixes the flaky unittest by replacing the wall-clock time dependent test with a proper assertion of whether or not the `TimeoutException` has been raised or not. This is done by monkeypatching said exception and checking a global state within the unittest.

Because I am using pytest's `monkeypatch` fixture, I cannot combine this with the `unittest.Testcase` class which means I extracted this test into a separate class and replaced the unittest-specific `self.subTest` with `pytest-subtests`.

We are already using `pytest` to run our tests everywhere so I am not worried about the unittest-incompatible case here. Ideally, in the future I would like to move the suite to use pytest directly rather than have a mixture.

NOTE: The pytest subtests also have better support in the report

#### Before this PR:
```
% python -m pytest test/test_backpropagation.py -k 'test_backpropagate_timeout'
========================================================= test session starts ==========================================================
platform linux -- Python 3.11.11, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/oss/Files/Dev/Qiskit/qiskit-addon-obp
configfile: pyproject.toml
plugins: anyio-4.4.0, subtests-0.14.1
collected 3 items / 2 deselected / 1 selected

test/test_backpropagation.py .                                                                                                  [100%]

============================================== 1 passed, 1 skipped, 2 deselected in 2.53s ==============================================
```

#### After this PR
```
% python -m pytest test/test_backpropagation.py -k 'test_backpropagate_timeout'
========================================================= test session starts ==========================================================
platform linux -- Python 3.11.11, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/oss/Files/Dev/Qiskit/qiskit-addon-obp
configfile: pyproject.toml
plugins: anyio-4.4.0, subtests-0.14.1
collected 3 items / 2 deselected / 1 selected

test/test_backpropagation.py ,,,,,,-.                                                                                            [100%]

==================================== 1 passed, 1 skipped, 2 deselected, 6 subtests passed in 2.54s =====================================
```

In this case it is more obvious that the skipped test was a subtest which is not even shown in the previous report.

<hr/>

In the future we could consider moving completely over to pytest but that requires changing all the `self.subTest` (which can be changed in-place to `subtests.test`) but also all the `self.assertEqual` variations.