### PR TITLE
Fix bug in applying resets to operator

### DIFF
--- a/qiskit_addon_obp/backpropagation.py
+++ b/qiskit_addon_obp/backpropagation.py
@@ -186,7 +186,8 @@ def backpropagate(
                     non_trivial_slice = True
 
                     if op_node.name == "reset":
-                        observables_tmp[i] = apply_reset_to(observables_tmp[i], qargs_tmp[i][0])
+                        assert len(op_qargs) == 1
+                        observables_tmp[i] = apply_reset_to(observables_tmp[i], op_qargs[0])
                     else:
                         # Absorb gate into observable and update qubits on which the observable acts
                         observables_tmp[i], qargs_tmp[i] = apply_op_to(

--- a/releasenotes/notes/reset-bugfix-fec4bf4a951a6324.yaml
+++ b/releasenotes/notes/reset-bugfix-fec4bf4a951a6324.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fixed a bug in :func:`qiskit_addon_obp.backpropagate` which often caused resets to be applied to the correct qubit.
+    Fixed a bug in :func:`qiskit_addon_obp.backpropagate` which often caused resets to be applied to the wrong qubit.

--- a/releasenotes/notes/reset-bugfix-fec4bf4a951a6324.yaml
+++ b/releasenotes/notes/reset-bugfix-fec4bf4a951a6324.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a bug in :func:`qiskit_addon_obp.backpropagate` which often caused resets to be applied to the correct qubit.

--- a/test/test_backpropagation.py
+++ b/test/test_backpropagation.py
@@ -212,7 +212,7 @@ class TestBackpropagation(unittest.TestCase):
             new_obs, reduced_slices, _ = backpropagate(obs, [qc])
             # Z term with coefficient 0.5 should be truncated now
             self.assertEqual([], reduced_slices)
-            self.assertEqual(SparsePauliOp("I", coeffs=[0.0]), new_obs)
+            self.assertEqual(SparsePauliOp("IX"), new_obs)
         with self.subTest("simplify"):
             qc = QuantumCircuit(1)
             qc.reset(0)

--- a/test/test_backpropagation.py
+++ b/test/test_backpropagation.py
@@ -203,9 +203,9 @@ class TestBackpropagation(unittest.TestCase):
             # Z term with coefficient 0.5 should be truncated now
             self.assertEqual([], reduced_slices)
         with self.subTest("reset"):
-            qc = QuantumCircuit(1)
-            qc.reset(0)
-            obs = SparsePauliOp("X")
+            qc = QuantumCircuit(2)
+            qc.reset(1)
+            obs = SparsePauliOp("ZX")
 
             new_obs, reduced_slices, _ = backpropagate(obs, [qc])
             # Z term with coefficient 0.5 should be truncated now

--- a/test/utils/test_operations.py
+++ b/test/utils/test_operations.py
@@ -211,36 +211,31 @@ class TestOperationsFunctions(unittest.TestCase):
     def test_apply_reset_to(self):
         with self.subTest("Basic test."):
             op = SparsePauliOp(["XYZ", "YZX", "ZXY"], coeffs=[1.0, 2.0, 3.0])
-            target_op = SparsePauliOp(["XYI", "YZI", "ZXY"], coeffs=[1.0, 0.0, 0.0])
-            target_op.paulis.x[2][0] = False
-            target_op.paulis.z[2][0] = False
+            target_op = SparsePauliOp(["XYI"], coeffs=[1.0])
             qubit_id = 0
             new_op = apply_reset_to(op, qubit_id)
+            new_op = new_op.simplify()
             self.assertEqual(target_op, new_op)
 
-            target_op = SparsePauliOp(["XYZ", "YIX", "ZIY"], coeffs=[0.0, 2.0, 0.0])
-            target_op.paulis.x[0][1] = False
-            target_op.paulis.z[0][1] = False
+            target_op = SparsePauliOp(["YIX"], coeffs=[2.0])
             qubit_id = 1
             new_op = apply_reset_to(op, qubit_id)
+            new_op = new_op.simplify()
             self.assertEqual(target_op, new_op)
 
-            target_op = SparsePauliOp(["IYZ", "YZX", "IXY"], coeffs=[0.0, 0.0, 3.0])
-            target_op.paulis.x[1][2] = False
-            target_op.paulis.z[1][2] = False
+            target_op = SparsePauliOp(["IXY"], coeffs=[3.0])
             qubit_id = 2
             new_op = apply_reset_to(op, qubit_id)
-
+            new_op = new_op.simplify()
             self.assertEqual(target_op, new_op)
 
         with self.subTest("Inplace"):
             op = SparsePauliOp(["XYZ", "YZX", "ZXY"], coeffs=[1.0, 2.0, 3.0])
-            target_op = SparsePauliOp(["XYI", "YZI", "ZXY"], coeffs=[1.0, 0.0, 0.0])
-            target_op.paulis.x[2][0] = False
-            target_op.paulis.z[2][0] = False
+            target_op = SparsePauliOp(["XYI"], coeffs=[1.0])
             qubit_id = 0
             new_op = apply_reset_to(op, qubit_id, inplace=True)
             self.assertEqual(op, new_op)
+            new_op = new_op.simplify()
             self.assertEqual(target_op, new_op)
 
     def test_apply_ple_to(self):


### PR DESCRIPTION
This PR fixes a bug causing resets to be applied to the wrong operator qubit