### PR TITLE
Update intersphinx mapping URLs & others

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ### About
 
-[Qiskit addons](https://docs.quantum.ibm.com/guides/addons) are a collection of modular tools for building utility-scale workloads powered by Qiskit.
+[Qiskit addons](https://quantum.cloud.ibm.com/docs/guides/addons) are a collection of modular tools for building utility-scale workloads powered by Qiskit.
 
 This package contains the Qiskit addon for operator backpropagation (OBP). Experimental errors limit the depth of quantum circuits that can be executed on near-term devices. OBP is a technique to reduce circuit depth by trimming operations from its end at the cost of more operator measurements.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,8 +102,8 @@ modindex_common_prefix = ["qiskit_addon_obp."]
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
-    "qiskit-ibm-runtime": ("https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
+    "qiskit-ibm-runtime": ("https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/", None),
     "rustworkx": ("https://www.rustworkx.org/", None),
     "qiskit_addon_utils": ("https://qiskit.github.io/qiskit-addon-utils/", None),
 }

--- a/docs/how_tos/truncate_operator_terms.ipynb
+++ b/docs/how_tos/truncate_operator_terms.ipynb
@@ -714,7 +714,7 @@
    "source": [
     "Since we passed a subset of our slices (i.e. ``slices[-num_slices:]``) to ``backpropagate``, we must combine the slices remaining after backpropagation with the slices that were never sent for backpropagation (i.e. ``slices[:-num_slices]``).\n",
     "\n",
-    "Once we have combined all of the remaining slices, we can use [combine_slices](https://qiskit.github.io/qiskit-addon-utils/stubs/qiskit_addon_utils.slicing.combine_slices.html#qiskit_addon_utils.slicing.combine_slices) to generate the reduced-depth [QuantumCircuit](https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.QuantumCircuit#html). Here we inspect how many slices were backpropagated vs. how large our observable became."
+    "Once we have combined all of the remaining slices, we can use [combine_slices](https://qiskit.github.io/qiskit-addon-utils/stubs/qiskit_addon_utils.slicing.combine_slices.html#qiskit_addon_utils.slicing.combine_slices) to generate the reduced-depth [QuantumCircuit](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.circuit.QuantumCircuit#html). Here we inspect how many slices were backpropagated vs. how large our observable became."
    ]
   },
   {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 Qiskit addon: operator backpropagation (OBP)
 ############################################
 
-`Qiskit addons <https://docs.quantum.ibm.com/guides/addons>`_ are a collection of modular tools for building utility-scale workloads powered by Qiskit.
+`Qiskit addons <https://quantum.cloud.ibm.com/docs/guides/addons>`_ are a collection of modular tools for building utility-scale workloads powered by Qiskit.
 
 This package contains the Qiskit addon for operator backpropagation (OBP).
 Experimental errors limit the depth of quantum circuits that can be executed

--- a/docs/tutorials/01_getting_started.ipynb
+++ b/docs/tutorials/01_getting_started.ipynb
@@ -17,7 +17,7 @@
    "id": "2cbd99bb-edc8-4032-8253-2f7195080aaa",
    "metadata": {},
    "source": [
-    "In this tutorial we will implement a [Qiskit pattern](https://docs.quantum.ibm.com/run/quantum-serverless#qiskit-patterns-with-quantum-serverless) for simulating the quantum dynamics of a Heisenberg spin chain using operator backpropagation:\n",
+    "In this tutorial we will implement a [Qiskit pattern](https://quantum.cloud.ibm.com/docs/guides/serverless#qiskit-patterns-with-quantum-serverless) for simulating the quantum dynamics of a Heisenberg spin chain using operator backpropagation:\n",
     "\n",
     "- **Step 1: Map to quantum problem**\n",
     "    - Map the time-evolved Hamiltonian onto a quantum circuit\n",
@@ -27,11 +27,11 @@
     "    - Combine the remaining slices into a single circuit\n",
     "    - Transpile the circuit for the backend\n",
     "- **Step 3: Execute experiments**\n",
-    "    - Calculate the expectation value using the reduced circuit and expanded observable with a [StatevectorEstimator](https://docs.quantum.ibm.com/api/qiskit/qiskit.primitives.StatevectorEstimator) for sake of simplicity in this notebook\n",
+    "    - Calculate the expectation value using the reduced circuit and expanded observable with a [StatevectorEstimator](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.primitives.StatevectorEstimator) for sake of simplicity in this notebook\n",
     "- **Step 4: Reconstruct results**\n",
     "    - N.A.\n",
     "\n",
-    "**Note:** Qiskit loosely describes [layers](https://docs.quantum.ibm.com/api/qiskit/qiskit.dagcircuit.DAGCircuit) as being depth-1 partitions of the circuit across all qubits. This package makes use of the term **slices** to describe layers of arbitrary depth. The [qiskit_addon_obp.backpropagate](https://qiskit.github.io/qiskit-addon-obp/stubs/qiskit_addon_obp.backpropagate.html) function is designed to backpropagate entire slices at a time, so the choice of how to slice the quantum circuit can have a major impact on how well backpropagation performs for a given problem. You will lean more about **slices** below."
+    "**Note:** Qiskit loosely describes [layers](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.dagcircuit.DAGCircuit) as being depth-1 partitions of the circuit across all qubits. This package makes use of the term **slices** to describe layers of arbitrary depth. The [qiskit_addon_obp.backpropagate](https://qiskit.github.io/qiskit-addon-obp/stubs/qiskit_addon_obp.backpropagate.html) function is designed to backpropagate entire slices at a time, so the choice of how to slice the quantum circuit can have a major impact on how well backpropagation performs for a given problem. You will lean more about **slices** below."
    ]
   },
   {
@@ -45,7 +45,7 @@
     "The [qiskit_addon_utils](https://qiskit.github.io/qiskit-addon-utils/) package provides some reusable functionalities for various purposes.\n",
     "\n",
     "Its [qiskit_addon_utils.problem_generators](https://qiskit.github.io/qiskit-addon-utils/stubs/qiskit_addon_utils.problem_generators.html) module provides functions to generate Heisenberg-like Hamiltonians on a given connectivity graph.\n",
-    "This graph can be either a [rustworkx.PyGraph](https://www.rustworkx.org/apiref/rustworkx.PyGraph.html) or a [CouplingMap](https://docs.quantum.ibm.com/api/qiskit/qiskit.transpiler.CouplingMap) making it easy to use in Qiskit-centric workflows.\n",
+    "This graph can be either a [rustworkx.PyGraph](https://www.rustworkx.org/apiref/rustworkx.PyGraph.html) or a [CouplingMap](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.transpiler.CouplingMap) making it easy to use in Qiskit-centric workflows.\n",
     "\n",
     "In the following, we first generate a heavy-hex `CouplingMap` out of which we carve a linear chain of 10 qubits. Note, that the indices of this new `reduced_coupling_map` are again zero-based."
    ]
@@ -406,7 +406,7 @@
    "source": [
     "### Now that we have our reduced ansatze and expanded observables, we can transpile our experiments to the backend.\n",
     "\n",
-    "Here we will use the 14-qubit [FakeMelbourneV2](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.fake_provider.FakeMelbourneV2) from [qiskit-ibm-runtime](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime) to demonstrate how to transpile to a QPU backend."
+    "Here we will use the 14-qubit [FakeMelbourneV2](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/fake-provider-fake-melbourne-v2) from [qiskit-ibm-runtime](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime) to demonstrate how to transpile to a QPU backend."
    ]
   },
   {
@@ -444,11 +444,11 @@
     "## Step 3: Execute quantum experiments\n",
     "### Calculate expectation value\n",
     "\n",
-    "Finally, we can run the backpropagated experiments and compare them with the full experiment using the noiseless [StatevectorEstimator](https://docs.quantum.ibm.com/api/qiskit/qiskit.primitives.StatevectorEstimator). We can see that the backpropagated expectation value without truncation is equivalent to the exact value within the limits of numerical precision.\n",
+    "Finally, we can run the backpropagated experiments and compare them with the full experiment using the noiseless [StatevectorEstimator](https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.primitives.StatevectorEstimator). We can see that the backpropagated expectation value without truncation is equivalent to the exact value within the limits of numerical precision.\n",
     "\n",
     "The expectation value on the operator with truncated terms has some error on the order of ``1e-4``, which is within the expected tolerance.\n",
     "\n",
-    "**Note:** We use a statevector-based ``Estimator`` primitive to illustrate the effect of truncation on the output. To run on the backend to which the experiments were transpiled in Step 2, one would import the [EstimatorV2](https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.EstimatorV2) from ``qiskit-ibm-runtime`` and pass the backend instance into the constructor."
+    "**Note:** We use a statevector-based ``Estimator`` primitive to illustrate the effect of truncation on the output. To run on the backend to which the experiments were transpiled in Step 2, one would import the [EstimatorV2](https://quantum.cloud.ibm.com/docs/api/qiskit-ibm-runtime/estimator-v2) from ``qiskit-ibm-runtime`` and pass the backend instance into the constructor."
    ]
   },
   {


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.