### PR TITLE
Add `OBPEstimator`

### DIFF
--- a/qiskit_addon_obp/obp_estimator.py
+++ b/qiskit_addon_obp/obp_estimator.py
@@ -1,0 +1,112 @@
+from dataclasses import asdict
+from typing import Callable
+
+import numpy as np
+from qiskit import QuantumCircuit
+from qiskit.primitives import StatevectorEstimator
+from qiskit.primitives.containers import PrimitiveResult
+from qiskit.primitives.containers.data_bin import DataBin
+from qiskit.primitives.containers.estimator_pub import EstimatorPub
+from qiskit.primitives.containers.pub_result import PubResult
+from qiskit.quantum_info import Pauli, SparsePauliOp, StabilizerState
+
+from qiskit_addon_obp import backpropagate
+from qiskit_addon_obp.utils.metadata import OBPMetadata
+from qiskit_addon_obp.utils.simplify import OperatorBudget
+from qiskit_addon_obp.utils.truncating import TruncationErrorBudget
+
+from .utils.broadcast_indices_iter import broadcast_indicies_iter
+
+
+class OBPEstimator(StatevectorEstimator):
+    # This is only done to avoid repeating of some of the abstract methods required
+    # by the BaseEstimatorV2 class. This code does not call the AerSimulator or
+    # StateVector simulator at all.
+
+    def __init__(
+        self,
+        slicer: Callable | None = None,
+        operator_budget: OperatorBudget | None = None,
+        truncation_error_budget: TruncationErrorBudget | None = None,
+        max_seconds: int | None = None,
+    ):
+        if slicer is None:
+
+            def _slicer(qc):
+                return [qc]
+
+            self._slicer = _slicer
+        else:
+            self._slicer = slicer
+
+        self._operator_budget = operator_budget
+        self._truncation_error_budget = truncation_error_budget
+        self._max_seconds = max_seconds
+        super().__init__()
+
+    def _run(self, pubs: list[EstimatorPub]) -> PrimitiveResult[PubResult]:
+        return super()._run(list(pubs))
+
+    def _run_pub(self, pub: EstimatorPub) -> PubResult:
+        shape = pub.shape if pub.shape else (1,)
+        evs = np.ones(shape, dtype=complex) * np.nan
+        obp_metadata_array = np.ones(shape, dtype=object) * np.nan
+
+        inds = broadcast_indicies_iter(
+            pub.observables.shape,
+            pub.parameter_values.shape,
+        )
+
+        _par_idx_prev = None
+        for obs_idx, par_idx, ev_idx in inds:
+            if _par_idx_prev != par_idx:
+                bound_circ = pub.parameter_values.bind(
+                    circuit=pub.circuit,
+                    loc=par_idx,
+                )
+                bound_qc_slices = self._slicer(bound_circ)
+
+            _ev, _obp_metadata = self._run_pub_idx(
+                qc=bound_circ,
+                obs=pub.observables[obs_idx],
+                pre_sliced_qc=bound_qc_slices,
+            )
+
+            evs[ev_idx] = _ev
+            obp_metadata_array[ev_idx] = asdict(_obp_metadata)
+
+        pub_res = PubResult(
+            data=DataBin(shape=evs.shape, evs=evs, obp_metadata=obp_metadata_array)
+        )
+        pub_res.metadata["circuit_metadata"] = pub.circuit.metadata.copy()
+
+        return pub_res
+
+    def _run_pub_idx(
+        self,
+        qc: QuantumCircuit,
+        obs: SparsePauliOp,
+        pre_sliced_qc: list[QuantumCircuit] | None = None,
+    ) -> tuple[float | complex, OBPMetadata]:
+        new_obs_list, new_qc, obp_metadata = backpropagate(
+            observables=[SparsePauliOp.from_list([(_p, _c) for _p, _c in obs.items()])],
+            slices=self._slicer(qc=qc) if pre_sliced_qc is None else pre_sliced_qc,
+            operator_budget=self._operator_budget,
+        )
+        new_obs: SparsePauliOp = new_obs_list[0]
+
+        if new_qc:
+            # In this case, one alternative is to have the user supply an auxiliary estimator
+            # The auxiliary estimator would compute the expectation value wrt the remaining
+            # slices. E.g. The primary use case would likely be providing an estimator which
+            # uses an actual backend to compute the remaining expectation value, etc.
+            raise NotImplementedError(
+                "Observable did not push through circuit entirely, this is not yet supported"
+            )
+
+        _stab_state = StabilizerState(QuantumCircuit(qc.num_qubits))
+        _ev = 0
+        for _ps, _c in new_obs.to_list():
+            _ev += _c * _stab_state.expectation_value(Pauli(_ps))
+
+        return _ev, obp_metadata

--- a/qiskit_addon_obp/utils/broadcast_indices_iter.py
+++ b/qiskit_addon_obp/utils/broadcast_indices_iter.py
@@ -1,0 +1,31 @@
+# This code is a Qiskit project.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import numpy as np
+
+
+def broadcast_indicies_iter(shape_a: tuple[int, ...], shape_b: tuple[int, ...]):
+    len_a = int(np.prod(shape_a))
+    len_b = int(np.prod(shape_b))
+
+    shape_c = np.broadcast_shapes(shape_a, shape_b)
+
+    c_broadcast = np.broadcast(
+        np.arange(len_a).reshape((len_a, 1)),
+        np.arange(len_b).reshape((1, len_b)),
+    )
+    for _a_idx, _b_idx in c_broadcast:
+        a_idx = np.unravel_index(_a_idx, shape_a)
+        b_idx = np.unravel_index(_b_idx, shape_b)
+        c_idx = np.unravel_index(c_broadcast.index - 1, shape_c)
+
+        yield (a_idx, b_idx, c_idx)


### PR DESCRIPTION
This PR adds an Estimator interface to OBP. This allows the user to compute expectation values using `qiskit_addon_obp.backpropagate`. This interface allows for arbitrarily shaped `EstimatorPub`s, handles parameter bindings, etc.

There are likely some remaining questions before this should be merged if at all, but IMO an Estimator interface of some sort is a natural addition.

For example, currently: if the remaining circuit after backpropagation is non-empty, the `OBPEstimator` will raise a `NotImplementedError`. I left a comment with a potential suggestion for how to handle this case:

```
            # In this case, one alternative is to have the user supply an auxiliary estimator
            # The auxiliary estimator would compute the expectation value wrt the remaining
            # slices. E.g. The primary use case would likely be providing an estimator which
            # uses an actual backend to compute the remaining expectation value, etc.
```

# Usage

```python
import numpy as np
from qiskit import QuantumCircuit
from qiskit.primitives.containers.estimator_pub import EstimatorPub
from qiskit.primitives.containers.observables_array import ObservablesArray
from qiskit.quantum_info import SparsePauliOp
from qiskit_addon_utils.slicing import slice_by_barriers

from qiskit_addon_obp.obp_estimator import OBPEstimator

# Make your EstimatorPub

theta = np.pi / 6
qc = QuantumCircuit(1)
qc.rz(theta, 0)
qc.barrier()
qc.ry(theta, 0)
obs = SparsePauliOp("X")
pub = EstimatorPub(qc, ObservablesArray([obs]))

# Compute EVs with OBP
OBPEstimator(slicer=slice_by_barriers).run([pub]).result()[0].data.evs
```

```
array([0.5+0.j])
```