### PR TITLE
fix: specify the optional dependency for unittests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ basetest = [
     "pytest-cov>=5.0",
     "pytest-subtests>=0.13",
     "qiskit-addon-utils",
+    "sympy>=1.3",
 ]
 test = [
     "qiskit-addon-obp[basetest]",


### PR DESCRIPTION
Qiskit 2.1 made `sympy` an optional rather than required dependency. It is used in our unittest suite to assert the correct handling of parameterized coefficients in a `SparsePauliOp` and, thus, required to be installed in our CI.